### PR TITLE
Fix duplicate UI on language change

### DIFF
--- a/resources/views/editor-panel.ejs
+++ b/resources/views/editor-panel.ejs
@@ -408,7 +408,9 @@
 
         addTabKeyEventListeners(tabs);
 
-        translatePanel.appendChild(tabs);
+        if (!translatePanel.firstChild) {
+          translatePanel.appendChild(tabs);
+        }
       }
 
       function buildUiForOrdinalString(translatePanel, targetLanguageCode) {
@@ -461,7 +463,9 @@
 
         addTabKeyEventListeners(tabs);
 
-        translatePanel.appendChild(tabs);
+        if (!translatePanel.firstChild) {
+          translatePanel.appendChild(tabs);
+        }
       }
 
       function buildUiForSelectString(translatePanel, stringIcuInfo) {
@@ -497,7 +501,9 @@
 
         addTabKeyEventListeners(tabs);
 
-        translatePanel.appendChild(tabs);
+        if (!translatePanel.firstChild) {
+          translatePanel.appendChild(tabs);
+        }
       }
 
       function buildUiForPluralWithSelectString(
@@ -580,7 +586,9 @@
           tabs.appendChild(tabDivElement);
         }
 
-        translatePanel.appendChild(tabs);
+        if (!translatePanel.firstChild) {
+          translatePanel.appendChild(tabs);
+        }
       }
 
       function buildUiForOrdinalWithSelectString(
@@ -670,7 +678,9 @@
           tabs.appendChild(tabDivElement);
         }
 
-        translatePanel.appendChild(tabs);
+        if (!translatePanel.firstChild) {
+          translatePanel.appendChild(tabs);
+        }
       }
 
       function buildUiForSelectWithPluralString(
@@ -753,7 +763,9 @@
           tabs.appendChild(tabDivElement);
         }
 
-        translatePanel.appendChild(tabs);
+        if (!translatePanel.firstChild) {
+          translatePanel.appendChild(tabs);
+        }
       }
 
       function buildUiForSelectWithOrdinalString(
@@ -842,7 +854,9 @@
           tabs.appendChild(tabDivElement);
         }
 
-        translatePanel.appendChild(tabs);
+        if (!translatePanel.firstChild) {
+          translatePanel.appendChild(tabs);
+        }
       }
 
       function styleTextArea(textArea) {

--- a/resources/views/editor-panel.ejs
+++ b/resources/views/editor-panel.ejs
@@ -286,6 +286,7 @@
       }
 
       function updateUiBasedOnSourceString(sourceString) {
+        removeCurrentUi();
         const stringIcuInfo = getStringIcuInfo(sourceString);
         if (stringIcuInfo) {
           makeUiEditorVisible();
@@ -1202,7 +1203,6 @@
 
         // Every other time
         AP.events.on("string.change", function (data) {
-          removeCurrentUi();
           updateUiBasedOnSourceString(data.text);
         });
       }

--- a/resources/views/editor-panel.ejs
+++ b/resources/views/editor-panel.ejs
@@ -1188,8 +1188,8 @@
 
       function removeCurrentUi() {
         const translatePanel = document.getElementById("translate-panel");
-        if (translatePanel.firstElementChild) {
-          translatePanel.firstElementChild.remove();
+        while (translatePanel.firstElementChild) {
+          translatePanel.removeChild(translatePanel.firstElementChild);
         }
         translationParsedIcu = {};
         translatePanel.removeAttribute("data-icu");


### PR DESCRIPTION
Previously, the UI was added twice if user changed language in the Editor.
This PR fixes that behaviour by checking if there already is any tabs in the UI before adding it to the UI.